### PR TITLE
Bump ruby, rubygems and bundler versions

### DIFF
--- a/rubian
+++ b/rubian
@@ -59,10 +59,10 @@ declare -ag cleanup_files=()
 declare -Ag legacy=(
 	[suite]=legacy
 
-	[version]=2.4.5
-	[major]=2.4
-	[sha256]=2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
-	[gem]=2.7.8
+	[version]=2.5.3
+	[major]=2.5
+	[sha256]=1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
+	[gem]=3.0.0
 	[bundler]=1.17.1
 )
 
@@ -70,22 +70,22 @@ declare -Ag legacy=(
 declare -Ag stable=(
 	[suite]=stable
 
-	[version]=2.5.3
-	[major]=2.5
-	[sha256]=1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
-	[gem]=2.7.8
-	[bundler]=1.17.1
+	[version]=2.6.0
+	[major]=2.6
+	[sha256]=acb00f04374899ba8ee74bbbcb9b35c5c6b1fd229f1876554ee76f0f1710ff5f
+	[gem]=3.0.1
+	[bundler]=1.17.2
 )
 
 # shellcheck disable=2034
 declare -Ag unstable=(
 	[suite]=unstable
 
-	[version]=2.6.0-preview2
+	[version]=2.6.0
 	[major]=2.6
-	[sha256]=00ddfb5e33dee24469dd0b203597f7ecee66522ebb496f620f5815372ea2d3ec
-	[gem]=3.0.0.beta1
-	[bundler]=1.17.1
+	[sha256]=acb00f04374899ba8ee74bbbcb9b35c5c6b1fd229f1876554ee76f0f1710ff5f
+	[gem]=3.0.1
+	[bundler]=2.0.0.pre.2
 )
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The following tools have been updated to these latest versions:

- `ruby`
- `gem`
- `bundler`