### PR TITLE
Fix unsupported version message

### DIFF
--- a/rubian
+++ b/rubian
@@ -774,7 +774,7 @@ ensure_arguments_really_available() {
 	local arg
 	for arg; do
 		local version=${available_version_by_string[$arg]:-}
-		[[ -n ${version:-} ]] || die "Unsupported version: $version"
+		[[ -n ${version:-} ]] || die "Unsupported version: $arg"
 
 		[[ -z ${seen[$version]:-} ]] || continue
 


### PR DESCRIPTION
Geçersiz veya desteklenmeyen bir sürüm bilgisi girildiğinde `Unsupported version: ` şeklinde bir çıktı oluyor, güncel listede ilgili sürüm bulunmadığı için `$version` değişkeni boş geliyor, desteklenmeyen sürüm numarası ekrana bastırılmıyordu. 

`$version` değişkeni yerine `$arg` değişkeni ile kullanıcı tarafından girilen argüman ekrana yazdırıldı.

Bu güncellemeyle, örneğin henüz yayımlanmamış `2.7.0` sürüm bilgisi girildiğinde `Unsupported version: 2.7.0` şekilde çıktı üretiyor.