### PR TITLE
Add a Ruby wrapper

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,3 @@
-Vagrant.configure("2") do |config|
-  config.vm.box = "omu/debian-stable-vanilla"
+Vagrant.configure(2) do |config|
+  config.vm.box = 'debian/contrib-buster64'
 end

--- a/rubian
+++ b/rubian
@@ -322,15 +322,14 @@ ruby_wrapper() {
 
 	[[ -x $wrapper ]] || bug "No binary found to wrap: $wrapper"
 
-	mv -f "$wrapper" "$real"
-	cat >"$wrapper" <<-EOF
-		#!/bin/sh
-		if [ -n "$RUBY_LD_PRELOAD" ] && [ -f "$RUBY_LD_PRELOAD" ] && [ -z "$LD_PRELOAD" ]; then
-			export LD_PRELOAD="$RUBY_LD_PRELOAD"
-		fi
-		exec "$real" "$@"
-	EOF
-	chmod +x "$wrapper"
+	mv -f "$wrapper" "$real"; {
+		cat <<-'EOF'
+			#!/bin/sh
+
+			[ -n "$RUBY_LD_PRELOAD" ] && [ -f "$RUBY_LD_PRELOAD" ] && [ -z "$LD_PRELOAD" ] && export LD_PRELOAD="$RUBY_LD_PRELOAD"
+		EOF
+		printf 'exec "%s" "%s"\n' "$real" '$@'
+	} >"$wrapper" && chmod +x "$wrapper"
 }
 
 ruby_install() {

--- a/rubian
+++ b/rubian
@@ -237,19 +237,6 @@ ruby_fetch() {
 	rm -f ruby.tar.xz
 }
 
-find_suitable_jemalloc() {
-	local libjemalloc
-
-	for libjemalloc in libjemalloc2 libjemalloc1; do
-		if apt-get install -s "$libjemalloc" &>/dev/null; then
-			echo "$libjemalloc"
-			return 0
-		fi
-	done
-
-	return 1
-}
-
 ruby_depends() {
 	local version=$1
 
@@ -280,14 +267,6 @@ ruby_depends() {
 	esac
 
 	local -a runtime_packages+=()
-
-	if [[ -z ${program_configuration[without_jemalloc]:-} ]]; then
-		local libjemalloc
-		if libjemalloc=$(find_suitable_jemalloc) && [[ -n ${libjemalloc:-} ]]; then
-			runtime_packages+=("$libjemalloc")
-			development_packages+=(libjemalloc-dev)
-		fi
-	fi
 
 	local package
 
@@ -322,10 +301,6 @@ ruby_build() {
 		'--prefix'
 		"$prefix"
 	)
-
-	if [[ -z ${program_configuration[without_jemalloc]:-} ]]; then
-		ruby_configure_arguments+=('--with-jemalloc')
-	fi
 
 	! is_inside_docker || CFLAGS='-DENABLE_PATH_CHECK=0'
 

--- a/rubian
+++ b/rubian
@@ -327,6 +327,7 @@ ruby_wrapper() {
 			#!/bin/sh
 
 			[ -n "$RUBY_LD_PRELOAD" ] && [ -f "$RUBY_LD_PRELOAD" ] && [ -z "$LD_PRELOAD" ] && export LD_PRELOAD="$RUBY_LD_PRELOAD"
+			[ -n "$RUBY_MALLOC_ARENA_MAX" ] && [ -z "$MALLOC_ARENA_MAX" ] && export MALLOC_ARENA_MAX="$RUBY_MALLOC_ARENA_MAX"
 		EOF
 		printf 'exec "%s" "%s"\n' "$real" '$@'
 	} >"$wrapper" && chmod +x "$wrapper"

--- a/rubian
+++ b/rubian
@@ -54,9 +54,6 @@ declare -ag ruby_slave_programs=(bundler bundle gem rake ri erb irb rdoc)
 # Description and synopsis for command help
 declare -Ag help_description help_synopsis
 
-# Program configuration keyed by options
-declare -Ag program_configuration=()
-
 # Sanitized arguments vector for the command
 declare -ag program_arguments=()
 

--- a/rubian
+++ b/rubian
@@ -309,6 +309,30 @@ ruby_build() {
 	make -j "$(nproc)"
 }
 
+ruby_wrapper() {
+	local version=$1
+
+	hey Setting up wrapper "$version"
+
+	local prefix
+	prefix=$(installation_prefix "$version")
+
+	local wrapper=$prefix/bin/ruby
+	local real=$wrapper.real
+
+	[[ -x $wrapper ]] || bug "No binary found to wrap: $wrapper"
+
+	mv -f "$wrapper" "$real"
+	cat >"$wrapper" <<-EOF
+		#!/bin/sh
+		if [ -n "$RUBY_LD_PRELOAD" ] && [ -f "$RUBY_LD_PRELOAD" ] && [ -z "$LD_PRELOAD" ]; then
+			export LD_PRELOAD="$RUBY_LD_PRELOAD"
+		fi
+		exec "$real" "$@"
+	EOF
+	chmod +x "$wrapper"
+}
+
 ruby_install() {
 	local version=$1
 
@@ -393,6 +417,7 @@ ruby_all() {
 	ruby_build "$version" || die "E: Building Ruby '$version' failed."
 
 	if ruby_install "$version"; then
+		ruby_wrapper "$version"
 		ruby_register "$version"
 	else
 		ruby_purge "$version"


### PR DESCRIPTION
Bu PR Jemalloc desteğini kaldırır ve #9 nolu iş kaydında listelenen çözümlerin (biri hariç tümüne) kolayca uygulanması için bir mekanizma sunar.  Mekanizmanın temelinde Ruby kurulumu sonrası program binary'sinin `ruby.real` adıyla rename edilmesi ve bunun yerine `ruby.real`'ı çalıştıran bir sarmalayıcı eklenmesi yatıyor.  (Sarmalayıcı POSIX shell'de exec yaptığından herhangi bir performans kaybı veya davranış değişikliği olmayacaktır.  Bu çok klasik ve etkili bir çözümdür.  Benzerlerini sistemde pek çok yerde bulabilirsiniz, örneğin Chrome launcher)

#### Çözüm 1 `MALLOC_ARENA_MAX` 

```sh
echo "RUBY_MALLOC_ARENA_MAX=2" >>/etc/environment
```

komutuyla `/etc/environment` dosyası ayarlanırsa Ruby daima `MALLOC_ARENA_MAX=2` altında çalışır.  Diğer programlar bu ayardan etkilenmez.  (Hepsine uygulansın istiyorsanız `RUBY_` önekini kaldırın.

#### Çözüm 2 Jemalloc

Uygun Jemalloc paketini kurarak `/etc/environment` dosyasında `RUBY_LD_PRELOAD` değişkenini ayarla.  Örneğin 5.1 için:

```sh
apt-get install libjemalloc2
echo 'RUBY_LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2' >>/etc/environment
```

Bu ayarlama sonrasında ilgili kitaplığı sadece Ruby'nin kullandığını not edin (yan etki yok).

#### Çözüm 3 Tcmalloc

Uygun Tcmalloc paketini kurarak `/etc/environment` dosyasında `RUBY_LD_PRELOAD` değişkenini ayarla.

```sh
apt-get install libtcmalloc-minimal4
echo 'RUBY_LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4' >>/etc/environment
```

Bu ayarlama sonrasında ilgili kitaplığı sadece Ruby'nin kullandığını not edin (yan etki yok).

#### Çözüm 4 Malloc Trim

Kaynak kodda yamalama gerektiğinden bunu desteklemiyoruz, üst geliştirici tarafından çözülmesini beklemek daha doğru.

Fixes #9 