### PR TITLE
Quote expansions in case patterns

### DIFF
--- a/rubian
+++ b/rubian
@@ -485,8 +485,8 @@ priority() {
 	local lowest_priority_prefix=${3:-}
 
 	case $prefix in
-	$highest_priority_prefix) echo 30 ;;
-	$lowest_priority_prefix)  echo 10 ;;
+	"$highest_priority_prefix") echo 30 ;;
+	"$lowest_priority_prefix")  echo 10 ;;
 	*)                        echo 20 ;;
 	esac
 }


### PR DESCRIPTION
ShellCheck 0.7.1 sürümünde aşağıdaki hatayı alıyorduk:

```
In ./rubian line 488:
        $highest_priority_prefix) echo 30 ;;
        ^----------------------^ SC2254: Quote expansions in case patterns to match literally rather than as a glob.


In ./rubian line 489:
        $lowest_priority_prefix)  echo 10 ;;
        ^---------------------^ SC2254: Quote expansions in case patterns to match literally rather than as a glob.

For more information:
  https://www.shellcheck.net/wiki/SC2254 -- Quote expansions in case patterns...
```

Bu PR'da yukarıdaki hatayı gidermek için gerekli düzenleme yapıldı.